### PR TITLE
Remove deprecated arg

### DIFF
--- a/bogo.php
+++ b/bogo.php
@@ -43,7 +43,7 @@ add_action( 'plugins_loaded', 'bogo_plugins_loaded', 10, 0 );
 
 function bogo_plugins_loaded() {
 	load_plugin_textdomain( 'bogo',
-		'wp-content/plugins/bogo/languages',
+		false,
 		'bogo/languages'
 	);
 }


### PR DESCRIPTION
See https://developer.wordpress.org/reference/functions/load_plugin_textdomain/

The second argument of `load_plugin_textdomain()` is marked deprecated long ago.

See #2