### PR TITLE
Correct bogo_get_user_accessible_locales()

### DIFF
--- a/admin/includes/user.php
+++ b/admin/includes/user.php
@@ -55,12 +55,6 @@ function bogo_set_accessible_locales( $profileuser ) {
 
 	$accessible_locales = bogo_get_user_accessible_locales( $profileuser->ID );
 
-	if ( empty( $accessible_locales ) ) {
-		$accessible_locales = array_keys( $available_languages );
-	} else {
-		$accessible_locales = bogo_filter_locales( $accessible_locales );
-	}
-
 ?>
 
 <!-- Bogo plugin -->

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -18,12 +18,11 @@ function bogo_map_meta_cap( $caps, $cap, $user_id, $args ) {
 		$caps[] = $meta_caps[$cap];
 	}
 
-	static $accessible_locales = array();
+	static $accessible_locales = null;
 
-	if ( empty( $accessible_locales ) ) {
-		$accessible_locales = bogo_filter_locales(
-			bogo_get_user_accessible_locales( $user_id )
-		);
+	if ( 'bogo_access_all_locales' !== $cap
+	and null === $accessible_locales ) {
+		$accessible_locales = bogo_get_user_accessible_locales( $user_id );
 	}
 
 	if ( 'bogo_access_locale' === $cap

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -268,7 +268,7 @@ function bogo_available_locales( $args = '' ) {
 
 		$available_locales = array_intersect(
 			$available_locales,
-			(array) $user_accessible_locales
+			$user_accessible_locales
 		);
 	}
 

--- a/includes/user.php
+++ b/includes/user.php
@@ -103,12 +103,27 @@ function bogo_get_user_accessible_locales( $user_id ) {
 	global $wpdb;
 
 	$user_id = absint( $user_id );
+
+	if ( user_can( $user_id, 'bogo_access_all_locales' ) ) {
+		$locales = bogo_available_locales( array(
+			'exclude_enus_if_inactive' => true,
+		) );
+
+		return $locales;
+	}
+
 	$meta_key = $wpdb->get_blog_prefix() . 'accessible_locale';
 
-	$locales = get_user_meta( $user_id, $meta_key );
+	$locales = (array) get_user_meta( $user_id, $meta_key );
 
 	if ( bogo_is_enus_deactivated() ) {
 		$locales = array_diff( $locales, array( 'en_US' ) );
+	}
+
+	$locales = bogo_filter_locales( $locales );
+
+	if ( empty( $locales ) ) {
+		$locales = array( bogo_get_default_locale() );
 	}
 
 	return $locales;


### PR DESCRIPTION
Ensure bogo_get_user_accessible_locales() always returns an array with a locale at minimum.

See #84