### PR TITLE
Rename the function to bogo_get_short_name()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -309,7 +309,7 @@ function bogo_available_languages( $args = '' ) {
 		$lang = bogo_get_language( $locale );
 
 		if ( $args['short_name'] and bogo_locale_is_alone( $locale ) ) {
-			$lang = bogo_shorten_name( $lang );
+			$lang = bogo_get_short_name( $lang );
 		}
 
 		$lang = trim( $lang );
@@ -400,12 +400,30 @@ function bogo_locale_is_alone( $locale ) {
 	return strlen( $slug ) < strlen( $tag );
 }
 
-function bogo_shorten_name( $lang ) {
-	if ( preg_match( '/^([^()]+)/', $lang, $matches ) ) {
-		$lang = $matches[1];
+function bogo_get_short_name( $orig_name ) {
+	$short_name = $orig_name;
+
+	$langs_with_variants = array(
+		'中文',
+		'Français',
+		'Português',
+		'Español',
+	);
+
+	foreach ( $langs_with_variants as $lang ) {
+		if ( false !== strpos( $orig_name, $lang ) ) {
+			$short_name = $lang;
+			break;
+		}
 	}
 
-	return trim( $lang );
+	if ( preg_match( '/^([^()]+)/', $short_name, $matches ) ) {
+		$short_name = $matches[1];
+	}
+
+	$short_name = apply_filters( 'bogo_get_short_name', $short_name, $orig_name );
+
+	return trim( $short_name );
 }
 
 function bogo_get_lang_regex() {

--- a/includes/language-switcher.php
+++ b/includes/language-switcher.php
@@ -118,7 +118,7 @@ function bogo_language_switcher_links( $args = '' ) {
 		$native_name = bogo_get_language_native_name( $code );
 
 		if ( bogo_locale_is_alone( $code ) ) {
-			$native_name = bogo_shorten_name( $native_name );
+			$native_name = bogo_get_short_name( $native_name );
 		}
 
 		$link = array(


### PR DESCRIPTION
- Rename the function to bogo_get_short_name()
- Apply bogo_get_short_name filter to the output
- Support languages that don't use (...) for variants

See #95